### PR TITLE
Fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sahedul Islam Rony
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ WIN_SRC = src/main.cpp src/utils/file_utils.cpp src/utils/logger.cpp src/utils/e
 
 LINUX_TARGET = $(DIST_DIR)/linux
 WIN_TARGET = $(DIST_DIR)/win.exe
-
-all: linux
+all: linux win
 
 prepare:
 	@mkdir -p $(DIST_DIR)
@@ -18,7 +17,7 @@ linux: prepare
 	$(CXX) $(CXXFLAGS) $(LINUX_SRC) -o $(LINUX_TARGET) -ludev
 
 win: prepare
-	x86_64-w64-mingw32-g++ -std=c++17 -Wall -Iinclude $(WIN_SRC) -o $(WIN_TARGET) -luser32 -lgdi32
+	x86_64-w64-mingw32-g++ -std=c++17 -Wall -Iinclude -Isrc $(WIN_SRC) -o $(WIN_TARGET) -luser32 -lgdi32
 
 test-utils: prepare
 	$(CXX) $(CXXFLAGS) src/utils/test_file_utils.cpp -o $(DIST_DIR)/test_file_utils


### PR DESCRIPTION
This pull request introduces a new license file to the project and updates the `Makefile` to enable Windows builds with improved include paths. Below is a summary of the most important changes grouped by theme.

### Licensing Updates:
* Added a new `LICENSE` file with the MIT License, granting permission for free use, modification, and distribution of the software under specified conditions.

### Build System Improvements:
* Updated the `Makefile` to include a `win` target alongside the existing `linux` target, enabling builds for Windows.
* Modified the `win` target in the `Makefile` to include the `src` directory in the include paths for better compatibility during compilation.